### PR TITLE
Fixes for vs code on Windows

### DIFF
--- a/build.jai
+++ b/build.jai
@@ -86,6 +86,9 @@
             }
 
             vscode_path = tprint("C:/Users/%/AppData/Local/Programs/Microsoft VS Code/Code.exe", username);
+            if !file_exists(vscode_path) {
+                vscode_path = "C:/Program Files/Microsoft VS Code/Code.exe"; // Try program files in case it's installed for all users
+            }
         }
 
         if OS == .MACOS {
@@ -114,6 +117,7 @@ message_loop :: (w: Workspace, args: []string, tracy: *Metaprogram_Plugin) {
 #import "Basic";
 #import "Compiler";
 #import "File";
+#import "File_Utilities";
 #import "String";
 #import "Process";
 #import "System";

--- a/server/cursor_context.jai
+++ b/server/cursor_context.jai
@@ -11,7 +11,7 @@ get_cursor_context :: (file: string, position: LSP_Position) -> []string {
         }
 
         if final_line == position.line {
-            pointer_index = it_index + position.character;
+            pointer_index = it_index + position.character + 1;
             break;
         }
     }
@@ -25,7 +25,7 @@ get_cursor_context :: (file: string, position: LSP_Position) -> []string {
     end_index := content.count;
 
     is_separator :: (char: u8) -> bool {
-        return is_any(char, " \n\t;*.[](){}=:#\",!+-/");
+        return is_any(char, " \r\n\t;*.[](){}=:#\",!+-/");
     }
 
 

--- a/server/goto.jai
+++ b/server/goto.jai
@@ -22,15 +22,16 @@ handle_import_or_load :: (workspace: *Project_Workspace, request: LSP_Request_Me
         if !ok {
             ok, uri = find_module_in_path(workspace.local_modules_directory, path);
         }
+        #if OS == .WINDOWS {
+            uri = tprint("file:///%", uri);
+        }
     } else {
         current_file := path_strip_filename(request.params.textDocument.uri);
         uri = tprint("%/%", current_file, path); 
     }
 
     if !module {
-         #if OS == .WINDOWS {
-             uri = slice(uri, 8, uri.count-1); // On windows file uris have triple slashes like this: file:///C:/folder/file.jai
-         } else {
+         #if OS != .WINDOWS {
              uri = slice(uri, 7, uri.count-1);
          }
     }

--- a/server/program.jai
+++ b/server/program.jai
@@ -204,6 +204,9 @@ find_declarations :: (workspace: *Project_Workspace, name: string, available_fro
 declaration_to_lsp_location :: (decl: Declaration) -> LSP_Location {
     uri := decl.location.file;
     // #if OS == .WINDOWS then uri = slice(uri, 3, uri.count-1);
+    #if OS == .WINDOWS {
+        uri = tprint("file:///%", uri);
+    }
 
     range: LSP_Range;
     range.start.line      = xx max(decl.location.l0-1, 0);
@@ -336,6 +339,12 @@ send_compiler_errors_as_diagnostics :: (workspace: *Project_Workspace, output: s
     diagnostics: [1]LSP_Diagnostic;
     diagnostics[0] = diagnostic;
 
+    #if OS == .WINDOWS {
+        file = tprint("file:///%", file);
+    }
+
+    file = copy_string(file); // split_from_right and slice don't allocate memory so copy the file in case the string with compiler output is freed
+
     lsp_send(LSP_Client_Message(LSP_Publish_Diagnostics).{
         method="textDocument/publishDiagnostics",
         params = .{
@@ -343,6 +352,10 @@ send_compiler_errors_as_diagnostics :: (workspace: *Project_Workspace, output: s
             diagnostics = diagnostics
         }
     });
+
+    if file != workspace.previously_errored_file {
+        free(workspace.previously_errored_file);
+    }
 
     workspace.previously_errored_file = file;
 }


### PR DESCRIPTION
I installed the vs code extension and it turns out that what worked for neovim didn't work for vs code. Here are the changes to make it work in both cases. I guess the LSP "standard" is open to interpretation :)

I also fixed an off by one error in goto definition that was causing goto not working if the cursor was on the first letter of the symbol.

That's all for today from me. If I find any more issues I'll try fixing them or let you know.