### PR TITLE
Correct name in the server info

### DIFF
--- a/server/lsp_interface.jai
+++ b/server/lsp_interface.jai
@@ -497,7 +497,7 @@ LSP_Result_Initialize :: struct {
     };
 
     serverInfo: struct {
-        name := "jsl";
+        name := "Jails";
         version := VERSION;
     };
 }


### PR DESCRIPTION
Missed this when renaming to Jails due to "jsl" typo.