### PR TITLE
WIP: (very WIP!) Completions for struct members

### DIFF
--- a/server/completition.jai
+++ b/server/completition.jai
@@ -13,8 +13,6 @@ handle_completitions :: (request: LSP_Request_Message_Completion) {
     cursor_pos := request.params.position;
     cursor_block := find_block(workspace, xx (cursor_pos.line+1), xx (cursor_pos.character+1), file_without_uri_prefix);
 
-    // TODO(BenJ) this actually finds the context "under" (past!) the cursor. We
-    // specifically want the thing _before_ the cursor
     path := get_cursor_context(file_without_uri_prefix, cursor_pos);
 
     completions: [..]LSP_Completion_Item;
@@ -28,60 +26,60 @@ handle_completitions :: (request: LSP_Request_Message_Completion) {
       // them TODO(BenJ) this will duplicate probably if it's even possible.
       decls := find_declarations(workspace, path[ 0 ], file_without_uri_prefix, cursor_block );
       if decls.count < 1 {
-        log( "No declaration for base member %", path[ 0 ] );
+          log( "No declaration for base member %", path[ 0 ] );
       } else {
-        for decl : decls {
-          current_decl := decl;
-          for part: array_view( path, 1, path.count-2 ) {
-            member_decl : *Declaration;
-            if current_decl.kind == {
-              case .ENUM; #through;
-              case .STRUCT; member_decl = find_struct_or_enum_member(workspace, current_decl, part);
-              case .EXPRESSION;
-                  type := get_type_declaration(workspace, (cast(*Expression) current_decl).type);
-                  if !type break;
-                  member_decl = find_struct_or_enum_member(workspace, type, part);
+          for decl : decls {
+              current_decl := decl;
+              for part: array_view( path, 1, path.count-2 ) {
+                  member_decl : *Declaration;
+                  if current_decl.kind == {
+                      case .ENUM; #through;
+                      case .STRUCT; member_decl = find_struct_or_enum_member(workspace, current_decl, part);
+                      case .EXPRESSION;
+                          type := get_type_declaration(workspace, (cast(*Expression) current_decl).type);
+                          if !type break;
+                          member_decl = find_struct_or_enum_member(workspace, type, part);
 
-              case .TYPE_INSTANTIATION;
-                  type := get_type_declaration(workspace, (cast(*Type_Instantiation) current_decl).type);
-                  if !type break;
-                  member_decl = find_struct_or_enum_member(workspace, type, part);
-            }
-            if !member_decl break;
-            current_decl = member_decl;
+                      case .TYPE_INSTANTIATION;
+                          type := get_type_declaration(workspace, (cast(*Type_Instantiation) current_decl).type);
+                          if !type break;
+                          member_decl = find_struct_or_enum_member(workspace, type, part);
+                  }
+                  if !member_decl break;
+                  current_decl = member_decl;
+              }
+
+              // Whatever we found, resolve its type to either a struct or a union
+              if current_decl.kind == {
+                  case .EXPRESSION;
+                      current_decl = get_type_declaration(workspace, (cast(*Expression) current_decl).type);
+                  case .TYPE_INSTANTIATION;
+                      current_decl = get_type_declaration(workspace, (cast(*Type_Instantiation) current_decl).type);
+              }
+
+              if !current_decl {
+                  break;
+              }
+
+              block: *Block;
+
+              // now actually find the block with the struc/union decl in it
+              if current_decl.kind == {
+                  case .ENUM; block = get_block(workspace, cast(*Enum) current_decl);
+                  case .STRUCT; block = get_block(workspace, cast(*Struct) current_decl);
+              }
+
+              if !block break;
+
+              for get_block_declarations(workspace, block) {
+                  array_add(*completions, .{
+                      label=it.name,
+                      kind=xx LSP_Completion_Item.Kind.Field,
+                      insertText=it.name,
+                      labelDetails = .{ description=it.name }
+                  });
+              }
           }
-
-          // Whatever we found, resolve its type to either a struct or a union
-          if current_decl.kind == {
-            case .EXPRESSION;
-              current_decl = get_type_declaration(workspace, (cast(*Expression) current_decl).type);
-            case .TYPE_INSTANTIATION;
-              current_decl = get_type_declaration(workspace, (cast(*Type_Instantiation) current_decl).type);
-          }
-
-          if !current_decl {
-            break;
-          }
-
-          block: *Block;
-
-          // now actually find the block with the struc/union decl in it
-          if current_decl.kind == {
-            case .ENUM; block = get_block(workspace, cast(*Enum) current_decl);
-            case .STRUCT; block = get_block(workspace, cast(*Struct) current_decl);
-          }
-
-          if !block break;
-
-          for get_block_declarations(workspace, block) {
-            array_add(*completions, .{
-                label=it.name,
-                kind=xx LSP_Completion_Item.Kind.Field,
-                insertText=it.name,
-                labelDetails = .{ description=it.name }
-            });
-          }
-        }
       }
     } else {
 

--- a/server/completition.jai
+++ b/server/completition.jai
@@ -8,7 +8,7 @@ handle_completitions :: (request: LSP_Request_Message_Completion) {
         return;
     }
 
-    refresh_program_if_needed(workspace);
+    //refresh_program_if_needed(workspace);
 
     cursor_pos := request.params.position;
     cursor_block := find_block(workspace, xx (cursor_pos.line+1), xx (cursor_pos.character+1), file_without_uri_prefix);

--- a/server/completition.jai
+++ b/server/completition.jai
@@ -8,37 +8,109 @@ handle_completitions :: (request: LSP_Request_Message_Completion) {
         return;
     }
 
+    refresh_program_if_needed(workspace);
+
     cursor_pos := request.params.position;
     cursor_block := find_block(workspace, xx (cursor_pos.line+1), xx (cursor_pos.character+1), file_without_uri_prefix);
 
+    // TODO(BenJ) this actually finds the context "under" (past!) the cursor. We
+    // specifically want the thing _before_ the cursor
+    path := get_cursor_context(file_without_uri_prefix, cursor_pos);
+
     completions: [..]LSP_Completion_Item;
+    defer array_free(completions);
 
-    for decl: workspace.program.declarations_by_name {
-        if decl.kind != .PROCEDURE continue;
+    if path.count > 1 {
+      // Looks like a struct or enum member. Find the decl for the penultimate
+      // thing, and offer its members as suggestions.
+      // So if we have [a, b, c, d], we want to inspect the members of c.
+      // We might find multiple decls for c (apparently) so we just add all of
+      // them TODO(BenJ) this will duplicate probably if it's even possible.
+      decls := find_declarations(workspace, path[ 0 ], file_without_uri_prefix, cursor_block );
+      if decls.count < 1 {
+        log( "No declaration for base member %", path[ 0 ] );
+      } else {
+        for decl : decls {
+          current_decl := decl;
+          for part: array_view( path, 1, path.count-2 ) {
+            member_decl : *Declaration;
+            if current_decl.kind == {
+              case .ENUM; #through;
+              case .STRUCT; member_decl = find_struct_or_enum_member(workspace, current_decl, part);
+              case .EXPRESSION;
+                  type := get_type_declaration(workspace, (cast(*Expression) current_decl).type);
+                  if !type break;
+                  member_decl = find_struct_or_enum_member(workspace, type, part);
 
-        if decl.flags & .SCOPE_FILE && file_without_uri_prefix != decl.location.file continue;
-        if !path_in_imported_modules_or_files(workspace, decl.location.file) continue;
+              case .TYPE_INSTANTIATION;
+                  type := get_type_declaration(workspace, (cast(*Type_Instantiation) current_decl).type);
+                  if !type break;
+                  member_decl = find_struct_or_enum_member(workspace, type, part);
+            }
+            if !member_decl break;
+            current_decl = member_decl;
+          }
 
-        if !(decl.flags & .IS_GLOBAL) {
-            decl_block := find_block(workspace, decl.location.l0, decl.location.c0, decl.location.file);
-            if !decl_block || !cursor_block || decl_block.serial != cursor_block.serial continue;
+          // Whatever we found, resolve its type to either a struct or a union
+          if current_decl.kind == {
+            case .EXPRESSION;
+              current_decl = get_type_declaration(workspace, (cast(*Expression) current_decl).type);
+            case .TYPE_INSTANTIATION;
+              current_decl = get_type_declaration(workspace, (cast(*Type_Instantiation) current_decl).type);
+          }
+
+          if !current_decl {
+            break;
+          }
+
+          block: *Block;
+
+          // now actually find the block with the struc/union decl in it
+          if current_decl.kind == {
+            case .ENUM; block = get_block(workspace, cast(*Enum) current_decl);
+            case .STRUCT; block = get_block(workspace, cast(*Struct) current_decl);
+          }
+
+          if !block break;
+
+          for get_block_declarations(workspace, block) {
+            array_add(*completions, .{
+                label=it.name,
+                kind=xx LSP_Completion_Item.Kind.Field,
+                insertText=it.name,
+                labelDetails = .{ description=it.name }
+            });
+          }
         }
+      }
+    } else {
 
-        procedure := cast(*Procedure) decl;
+      for decl: workspace.program.declarations_by_name {
+          if decl.kind != .PROCEDURE continue;
 
-        lsp_location := declaration_to_lsp_location(decl);
+          if decl.flags & .SCOPE_FILE && file_without_uri_prefix != decl.location.file continue;
+          if !path_in_imported_modules_or_files(workspace, decl.location.file) continue;
 
-        // @TODO: fix this (does not currently work for not opened files)
-        peeked_procedure := find_range_in_modified_file(decl.location.file, lsp_location.range);
+          if !(decl.flags & .IS_GLOBAL) {
+              decl_block := find_block(workspace, decl.location.l0, decl.location.c0, decl.location.file);
+              if !decl_block || !cursor_block || decl_block.serial != cursor_block.serial continue;
+          }
 
-        array_add(*completions, .{
-            label=procedure.name,
-            kind=xx LSP_Completion_Item.Kind.Function,
-            insertText=tprint("%()", decl.name),
-            labelDetails = .{ description=peeked_procedure }
-        });
+          procedure := cast(*Procedure) decl;
+
+          lsp_location := declaration_to_lsp_location(decl);
+
+          // @TODO: fix this (does not currently work for not opened files)
+          peeked_procedure := find_range_in_modified_file(decl.location.file, lsp_location.range);
+
+          array_add(*completions, .{
+              label=procedure.name,
+              kind=xx LSP_Completion_Item.Kind.Function,
+              insertText=decl.name,
+              labelDetails = .{ description=peeked_procedure }
+          });
+      }
     }
 
     lsp_respond(request.id, completions);
-    array_free(completions);
 }

--- a/server/cursor_context.jai
+++ b/server/cursor_context.jai
@@ -4,7 +4,7 @@ get_cursor_context :: (file: string, position: LSP_Position) -> []string {
     final_line: int;
     pointer_index: int = -1;
 
-    // @SPEED: This searching could be probably done faster if we had server.modified_files stored as array of lines instead of file content. 
+    // @SPEED: This searching could be probably done faster if we had server.modified_files stored as array of lines instead of file content.
     for char: content {
         if char == #char "\n" {
             final_line += 1;
@@ -30,15 +30,14 @@ get_cursor_context :: (file: string, position: LSP_Position) -> []string {
 
     rewind_count :int;
     while pointer_index > 0 && is_separator( content[ pointer_index ] ) && content[ pointer_index ] != #char "." {
-      // if we are requested on a separator, find the first non-separator character before this position.
-      // This feels natural when asking for the loctaion on the '.' of 'foobar.baz' -> return loc of foobar.
-      // Ditto for completion request of 'foobar.' -> return the members of 'foobar'
-      pointer_index -= 1;
+        // if we are requested on a separator, find the first non-separator character before this position.
+        // This feels natural when asking for the loctaion on the '.' of 'foobar.baz' -> return loc of foobar.
+        // Ditto for completion request of 'foobar.' -> return the members of 'foobar'
+        pointer_index -= 1;
 
-      // but for finding the "end" of the identifier sequence, we advance back past these separators
-      rewind_count += 1;
+        // but for finding the "end" of the identifier sequence, we advance back past these separators
+        rewind_count += 1;
     }
-
 
     // Start search
     for < index: pointer_index..0 {

--- a/server/cursor_context.jai
+++ b/server/cursor_context.jai
@@ -28,6 +28,17 @@ get_cursor_context :: (file: string, position: LSP_Position) -> []string {
         return is_any(char, " \r\n\t;*.[](){}=:#\",!+-/");
     }
 
+    rewind_count :int;
+    while pointer_index > 0 && is_separator( content[ pointer_index ] ) && content[ pointer_index ] != #char "." {
+      // if we are requested on a separator, find the first non-separator character before this position.
+      // This feels natural when asking for the loctaion on the '.' of 'foobar.baz' -> return loc of foobar.
+      // Ditto for completion request of 'foobar.' -> return the members of 'foobar'
+      pointer_index -= 1;
+
+      // but for finding the "end" of the identifier sequence, we advance back past these separators
+      rewind_count += 1;
+    }
+
 
     // Start search
     for < index: pointer_index..0 {
@@ -45,7 +56,7 @@ get_cursor_context :: (file: string, position: LSP_Position) -> []string {
     }
 
     // End search
-    for index: pointer_index..content.count-1 {
+    for index: (pointer_index + rewind_count)..content.count-1 {
         char := content[index];
         if is_separator(char) {
             end_index = index;

--- a/server/lsp_interface.jai
+++ b/server/lsp_interface.jai
@@ -125,7 +125,7 @@ LSP_Did_Open_Text_Document :: struct {
 LSP_Did_Save_Text_Document :: LSP_Did_Open_Text_Document;
 
 LSP_Content_Change :: struct {
-    range: LSP_Range;
+    range: *LSP_Range;
     text: string;
 }
 

--- a/server/main.jai
+++ b/server/main.jai
@@ -11,17 +11,16 @@ Args :: struct {
 }
 
 Document :: struct {
-  content: [..]u8;
-  line_start_indices: [..]u64;
+    content: [..]u8;
+    line_start_indices: [..]u64;
 
-  Client_Status :: enum {
-    CLOSED;
-    DIRTY;
-    SAVED;
-  };
-  client_status: Client_Status;
+    Client_Status :: enum {
+        CLOSED;
+        DIRTY;
+        SAVED;
+    };
+    client_status: Client_Status;
 }
-
 
 Server :: struct {
     args: Args;
@@ -197,7 +196,7 @@ handle_request :: (request: LSP_Request_Message, raw_request: string) {
                 if !success {
                     lsp_respond_with_error(body.id, .PARSE_ERROR, tprint("Could not run initial metaprogram run", workspace.entry), error_details);
                     // return; // We cant return here because LSP client is waiting for response - if he wont get one the editor thinks the LSP crashed...
-                }                
+                }
 
             }
 

--- a/server/main.jai
+++ b/server/main.jai
@@ -10,6 +10,19 @@ Args :: struct {
     jai_path: string = #run find_current_jai_path();
 }
 
+Document :: struct {
+  content: [..]u8;
+  line_start_indices: [..]u64;
+
+  Client_Status :: enum {
+    CLOSED;
+    DIRTY;
+    SAVED;
+  };
+  client_status: Client_Status;
+}
+
+
 Server :: struct {
     args: Args;
     quit := false;
@@ -18,7 +31,7 @@ Server :: struct {
     workspaces: []Project_Workspace;
 
     modified_files_lock: Mutex;
-    modified_files: Table(string, [..]u8); // @todo: This is probably dumb - store files as array of lines instead (is this good idea?) // @ToDo: Keep track of a modified flag per file
+    modified_files: Table(string, Document);
 }
 
 server: Server;
@@ -226,7 +239,7 @@ handle_request :: (request: LSP_Request_Message, raw_request: string) {
             file_path := body.params.textDocument.uri;
             content := body.params.textDocument.text;
 
-            create_modified_file(file_path, content);
+            create_modified_file(file_path, content, true);
 
         case "textDocument/didChange";
             success, body := json_parse_string(raw_request, LSP_Did_Change_Text_Document);

--- a/server/main.jai
+++ b/server/main.jai
@@ -29,14 +29,18 @@ server: Server;
 // It will also eliminate duplicated module cache across workspaces and also speedup
 // metaprogram processing time.
 find_workspace_by_path :: (path: string) -> *Project_Workspace {
+    file_without_uri_prefix := replace(path, "file://", "");
+
     for * workspace: server.workspaces {
-        if !contains(path, workspace.working_directory) && !path_in_imported_modules_or_files(workspace, path) {
+        if !contains(file_without_uri_prefix, workspace.working_directory) &&
+           !path_in_imported_modules_or_files(workspace, file_without_uri_prefix) {
             continue;
         }
 
         return workspace;
     }
 
+    log_error( "Workspace not found for file path %\n", file_without_uri_prefix);
     return *server.workspaces[0];
 }
 
@@ -246,7 +250,6 @@ handle_request :: (request: LSP_Request_Message, raw_request: string) {
                 return;
             }
 
-            // refresh_program_if_needed();
             handle_completitions(body);
 
     }

--- a/server/modified_files.jai
+++ b/server/modified_files.jai
@@ -8,9 +8,7 @@ deinit_modified_files :: () {
     deinit(*server.modified_files);
 }
 
-create_modified_file :: (file_path: string,
-                         content: string,
-                         is_client_owned: bool) {
+create_modified_file :: (file_path: string, content: string, is_client_owned: bool) {
     file_without_uri_prefix := replace(file_path, "file://", "");
     content_dynamic: [..]u8;
 
@@ -21,18 +19,18 @@ create_modified_file :: (file_path: string,
     defer unlock(*server.modified_files_lock);
 
     if !is_client_owned {
-      document, found := table_find( *server.modified_files, file_without_uri_prefix );
-      if found && document.client_status != .CLOSED {
-        // don't replace a client-owned buffer with one we read from disk
-        log( "Not clobbering client-owned modified file", file_without_uri_prefix );
-        return;
-      }
+        document, found := table_find( *server.modified_files, file_without_uri_prefix );
+        if found && document.client_status != .CLOSED {
+            // don't replace a client-owned buffer with one we read from disk
+            log( "Not clobbering client-owned modified file", file_without_uri_prefix );
+            return;
+        }
     }
 
     table_set(*server.modified_files, file_without_uri_prefix, .{
-      content = content_dynamic,
-      // line_start_indices = calc_line_start_indicies( content_dynamic ),
-      client_status = ifx is_client_owned then Document.Client_Status.DIRTY else .CLOSED,
+        content = content_dynamic,
+        // line_start_indices = calc_line_start_indicies( content_dynamic ),
+        client_status = ifx is_client_owned then Document.Client_Status.DIRTY else .CLOSED,
     });
     // dump_server_modified_files();
 
@@ -52,13 +50,13 @@ edit_modified_file :: (file_path: string, changes: []LSP_Content_Change) {
 
     content := document.content;
     for change: changes {
-      if change.range {
-          from := change.range.start;
-          to := change.range.end;
-          apply_change(document, from, to, xx change.text);
+        if change.range {
+            from := change.range.start;
+            to := change.range.end;
+            apply_change(document, from, to, xx change.text);
         } else {
-          // full file
-          apply_change_to_range(document, 0, content.count, xx change.text );
+            // full file
+            apply_change_to_range(document, 0, content.count, xx change.text );
         }
     }
 
@@ -130,7 +128,7 @@ find_line_in_modified_file :: (file: string, position: LSP_Position) -> string {
     start_index: int = -1;
     end_index := content.count;
 
-    // @SPEED: This searching could be probably done faster if we had server.modified_files stored as array of lines instead of file content. 
+    // @SPEED: This searching could be probably done faster if we had server.modified_files stored as array of lines instead of file content.
     for char: content {
         if char == #char "\n" {
             final_line += 1;
@@ -166,10 +164,10 @@ get_modified_file :: (name: string) -> []u8 {
 
     document, ok := table_find(*server.modified_files, file_without_uri_prefix);
     if !ok {
-      log("Didn't find modified file for %", file_without_uri_prefix);
+        log("Didn't find modified file for %", file_without_uri_prefix);
         return .[];
     } else {
-      log( "found modified file for %", file_without_uri_prefix);
+        log( "found modified file for %", file_without_uri_prefix);
     }
 
     return document.content;
@@ -209,10 +207,8 @@ apply_change :: (document: *Document, from: LSP_Position, to: LSP_Position, text
     }
 
     if start_index < 0 || end_index < 0 {
-      log( "didn't find the requested range in the document: %:% -> %:%\n",
-           from.line, from.character,
-           to.line, to.character );
-       return;
+        log( "didn't find the requested range in the document: %:% -> %:%\n", from.line, from.character, to.line, to.character );
+        return;
     }
 
     #if DEBUG_AC {

--- a/server/modified_files.jai
+++ b/server/modified_files.jai
@@ -8,7 +8,9 @@ deinit_modified_files :: () {
     deinit(*server.modified_files);
 }
 
-create_modified_file :: (file_path: string, content: string) {
+create_modified_file :: (file_path: string,
+                         content: string,
+                         is_client_owned: bool) {
     file_without_uri_prefix := replace(file_path, "file://", "");
     content_dynamic: [..]u8;
 
@@ -17,8 +19,24 @@ create_modified_file :: (file_path: string, content: string) {
 
     lock(*server.modified_files_lock);
     defer unlock(*server.modified_files_lock);
-    table_set(*server.modified_files, file_without_uri_prefix, content_dynamic);
+
+    if !is_client_owned {
+      document, found := table_find( *server.modified_files, file_without_uri_prefix );
+      if found && document.client_status != .CLOSED {
+        // don't replace a client-owned buffer with one we read from disk
+        log( "Not clobbering client-owned modified file", file_without_uri_prefix );
+        return;
+      }
+    }
+
+    table_set(*server.modified_files, file_without_uri_prefix, .{
+      content = content_dynamic,
+      // line_start_indices = calc_line_start_indicies( content_dynamic ),
+      client_status = ifx is_client_owned then Document.Client_Status.DIRTY else .CLOSED,
+    });
     // dump_server_modified_files();
+
+    log( "Created modified file %: %", file_without_uri_prefix, content_dynamic);
 }
 
 edit_modified_file :: (file_path: string, changes: []LSP_Content_Change) {
@@ -26,22 +44,25 @@ edit_modified_file :: (file_path: string, changes: []LSP_Content_Change) {
     lock(*server.modified_files_lock);
     defer unlock(*server.modified_files_lock);
 
-    content := table_find_pointer(*server.modified_files, file_without_uri_prefix);
-    if !content {
+    document := table_find_pointer(*server.modified_files, file_without_uri_prefix);
+    if !document {
         log_error("File is not in the cache %", file_without_uri_prefix);
         return;
     }
 
+    content := document.content;
     for change: changes {
       if change.range {
           from := change.range.start;
           to := change.range.end;
-          apply_change(content, from, to, xx change.text);
+          apply_change(document, from, to, xx change.text);
         } else {
           // full file
-          apply_change_to_range(content, 0, content.count, xx change.text );
+          apply_change_to_range(document, 0, content.count, xx change.text );
         }
     }
+
+    log( "Updated modified file %: %", file_without_uri_prefix, content );
 }
 
 remove_modified_file :: (file_path: string) {
@@ -53,13 +74,17 @@ remove_modified_file :: (file_path: string) {
     if !found {
         log_error("Tried to remove file % but it was not in the modified server.modified_files table!", file_without_uri_prefix);
     }
+
+    // TODO: SHouldn't we free the document contents ?
+
+    log( "Removed modified file: %", file_without_uri_prefix);
 }
 
 find_range_in_modified_file :: (file: string, range: LSP_Range) -> string {
     lock(*server.modified_files_lock);
     defer unlock(*server.modified_files_lock);
 
-    content, ok := table_find(*server.modified_files, file);
+    document, ok := table_find(*server.modified_files, file);
     if !ok {
         return "";
     }
@@ -69,6 +94,7 @@ find_range_in_modified_file :: (file: string, range: LSP_Range) -> string {
     end_index: int = -1;
 
     // We get index of starting and ending byte of the range.
+    content := document.content;
     for char: content {
         if current_line == range.start.line && start_index == -1 {
             start_index = it_index + range.start.character;
@@ -93,10 +119,12 @@ find_range_in_modified_file :: (file: string, range: LSP_Range) -> string {
 find_line_in_modified_file :: (file: string, position: LSP_Position) -> string {
     lock(*server.modified_files_lock);
     defer unlock(*server.modified_files_lock);
-    content, ok := table_find(*server.modified_files, file);
+    document, ok := table_find(*server.modified_files, file);
     if !ok {
         return "";
     }
+
+    content := document.content;
 
     final_line: int;
     start_index: int = -1;
@@ -131,15 +159,20 @@ find_line_in_modified_file :: (file: string, position: LSP_Position) -> string {
 }
 
 get_modified_file :: (name: string) -> []u8 {
+    file_without_uri_prefix := replace(name, "file://", "");
+
     lock(*server.modified_files_lock);
     defer unlock(*server.modified_files_lock);
 
-    content, ok := table_find(*server.modified_files, name);
+    document, ok := table_find(*server.modified_files, file_without_uri_prefix);
     if !ok {
+      log("Didn't find modified file for %", file_without_uri_prefix);
         return .[];
+    } else {
+      log( "found modified file for %", file_without_uri_prefix);
     }
 
-    return content;
+    return document.content;
 }
 
 #scope_file
@@ -150,12 +183,13 @@ DEBUG_AC :: true;
 // - unicode support
 // - {}, "", () when the editor (for example vscode) auto-closes parentheses behaves badly.
 // Mutates in memory file
-apply_change :: (content: *[..]u8, from: LSP_Position, to: LSP_Position, text: []u8) {
+apply_change :: (document: *Document, from: LSP_Position, to: LSP_Position, text: []u8) {
     current_line: int;
     start_index: int = -1;
     end_index: int = -1;
 
     // We get index of starting and ending byte of the range.
+    content := *document.content;
     for char: <<content {
         if current_line == from.line && start_index == -1 {
             start_index = it_index + from.character;
@@ -197,10 +231,12 @@ apply_change :: (content: *[..]u8, from: LSP_Position, to: LSP_Position, text: [
 
         log("- END (%)", end_index);
     }
-    apply_change_to_range(content, start_index, end_index, text );
+    apply_change_to_range(document, start_index, end_index, text );
 }
 
-apply_change_to_range :: (content: *[..]u8, start_index: int, end_index: int, text: []u8 ) {
+apply_change_to_range :: (document: *Document, start_index: int, end_index: int, text: []u8 ) {
+
+    content := *document.content;
 
     assert(content.count >= start_index && content.count >= end_index);
 

--- a/server/modified_files.jai
+++ b/server/modified_files.jai
@@ -9,6 +9,7 @@ deinit_modified_files :: () {
 }
 
 create_modified_file :: (file_path: string, content: string) {
+    file_without_uri_prefix := replace(file_path, "file://", "");
     content_dynamic: [..]u8;
 
     array_copy(*content_dynamic, cast([]u8) content);
@@ -16,34 +17,41 @@ create_modified_file :: (file_path: string, content: string) {
 
     lock(*server.modified_files_lock);
     defer unlock(*server.modified_files_lock);
-    table_set(*server.modified_files, file_path, content_dynamic);
+    table_set(*server.modified_files, file_without_uri_prefix, content_dynamic);
     // dump_server_modified_files();
 }
 
 edit_modified_file :: (file_path: string, changes: []LSP_Content_Change) {
+    file_without_uri_prefix := replace(file_path, "file://", "");
     lock(*server.modified_files_lock);
     defer unlock(*server.modified_files_lock);
 
-    content := table_find_pointer(*server.modified_files, file_path);
+    content := table_find_pointer(*server.modified_files, file_without_uri_prefix);
     if !content {
-        log_error("File is not in the cache %", file_path);
+        log_error("File is not in the cache %", file_without_uri_prefix);
         return;
     }
 
     for change: changes {
-        from := change.range.start;
-        to := change.range.end;
-        apply_change(content, from, to, xx change.text);
+      if change.range {
+          from := change.range.start;
+          to := change.range.end;
+          apply_change(content, from, to, xx change.text);
+        } else {
+          // full file
+          apply_change_to_range(content, 0, content.count, xx change.text );
+        }
     }
 }
 
 remove_modified_file :: (file_path: string) {
+    file_without_uri_prefix := replace(file_path, "file://", "");
     lock(*server.modified_files_lock);
     defer unlock(*server.modified_files_lock);
 
-    found := table_remove(*server.modified_files, file_path);
+    found := table_remove(*server.modified_files, file_without_uri_prefix);
     if !found {
-        log_error("Tried to remove file % but it was not in the modified server.modified_files table!", file_path);
+        log_error("Tried to remove file % but it was not in the modified server.modified_files table!", file_without_uri_prefix);
     }
 }
 
@@ -136,7 +144,7 @@ get_modified_file :: (name: string) -> []u8 {
 
 #scope_file
 
-DEBUG_AC :: false;
+DEBUG_AC :: true;
 
 // @todo:
 // - unicode support
@@ -166,6 +174,13 @@ apply_change :: (content: *[..]u8, from: LSP_Position, to: LSP_Position, text: [
         }
     }
 
+    if start_index < 0 || end_index < 0 {
+      log( "didn't find the requested range in the document: %:% -> %:%\n",
+           from.line, from.character,
+           to.line, to.character );
+       return;
+    }
+
     #if DEBUG_AC {
         log("from: %, to: % (reached line %)", from.line, to.line, current_line);
 
@@ -182,6 +197,10 @@ apply_change :: (content: *[..]u8, from: LSP_Position, to: LSP_Position, text: [
 
         log("- END (%)", end_index);
     }
+    apply_change_to_range(content, start_index, end_index, text );
+}
+
+apply_change_to_range :: (content: *[..]u8, start_index: int, end_index: int, text: []u8 ) {
 
     assert(content.count >= start_index && content.count >= end_index);
 

--- a/server/program.jai
+++ b/server/program.jai
@@ -509,7 +509,17 @@ listen_to_metaprogram :: (thread: *Thread) -> s64 {
 
             case .FILE;
                 file := deserialize(body_bytes, Source_File);
-                create_modified_file(file.path, read_entire_file(file.path)); // This is needed for code snippet peeks - for example to preview procedure header in completions... @TODO: We should rename modified_files to just files really...
+                // TODO/FIXME: THis will (incorrectly) override any actually
+                // modified data in this file. So say we had
+                // didOpen file.jai -> v1
+                // didChange file.jai -> v2
+                // <This> -> reads file.jai from disk -> .. ?!
+                // completions/definition request: uses file on disk, not the
+                // unsaved/modified buffer.
+                create_modified_file(file.path,
+                                     read_entire_file(file.path),
+                                     false);
+                                     // This is needed for code snippet peeks - for example to preview procedure header in completions... @TODO: We should rename modified_files to just files really...
                 array_add(*workspace.work_program.imported_files, <<file);
 
             case .STRUCT; add_to_program(workspace, body_bytes, Struct);

--- a/server/program.jai
+++ b/server/program.jai
@@ -509,17 +509,10 @@ listen_to_metaprogram :: (thread: *Thread) -> s64 {
 
             case .FILE;
                 file := deserialize(body_bytes, Source_File);
-                // TODO/FIXME: THis will (incorrectly) override any actually
-                // modified data in this file. So say we had
-                // didOpen file.jai -> v1
-                // didChange file.jai -> v2
-                // <This> -> reads file.jai from disk -> .. ?!
-                // completions/definition request: uses file on disk, not the
-                // unsaved/modified buffer.
+                // This is needed for code snippet peeks - for example to preview procedure header in completions... @TODO: We should rename modified_files to just files really...
                 create_modified_file(file.path,
                                      read_entire_file(file.path),
                                      false);
-                                     // This is needed for code snippet peeks - for example to preview procedure header in completions... @TODO: We should rename modified_files to just files really...
                 array_add(*workspace.work_program.imported_files, <<file);
 
             case .STRUCT; add_to_program(workspace, body_bytes, Struct);


### PR DESCRIPTION
This adds _very rough_ support for completion of struct members.

In order for this to work properly, I had to fix some ancillary things:

1. Consistently use the _real_ file path in the `modified_files` map; previously it was a sort of mix of URIs and paths.
2. REcord that a file in the `modified_files` map is actually "owned" by the client (via a `didOpen`) - this is very quick hack for now because the `.FILE` type message was clobbering it with the contents from disk. This needs to correctly unset (and probably re-read from disk) when `didClose` is called
3. requesting a "cursor context" on the `.` after a struct would return the _next_ tokens rather than previous. It feels more natural (and works for completion!) to return rewind and find the previous tokens.

Then in the completion handler, we resolve the tokens/identifier under the cursor and see if it looks like a `foo.bar.baz` type thing, then resolve the members and return them as completions. 

Much more is required for this to be "good" but sharing for context, discussion and/or testing.

here's it working in vscode:

<img width="633" alt="Screenshot 2023-05-18 at 12 52 03" src="https://github.com/SogoCZE/Jails/assets/10584846/05515c43-ac6e-432d-bfc0-b76aa429360e">


here's it working in YouCompleteMe (vim):

<img width="419" alt="Screenshot 2023-05-18 at 12 51 23" src="https://github.com/SogoCZE/Jails/assets/10584846/65cce4be-3e87-4f90-8b64-d4d34d5054d7">


<img width="371" alt="Screenshot 2023-05-18 at 12 51 35" src="https://github.com/SogoCZE/Jails/assets/10584846/b88c5151-4b84-4396-aec7-b51a30728772">
