### PR TITLE
update dependency in README from @vscode/vsc to @types/vscode

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -20,7 +20,7 @@ Compile the release version of the server with `jai build.jai - -release`. Jails
 
 ### VS Code
 1. Make sure this repo is your working directory (e.g. `cd Jails`).
-2. Run `npm install --global @vscode/vsce` to install the Visual Studio Code Extension Manager.
+2. Run `npm install --global @types/vscode` to install the Visual Studio Code Extension Manager.
 3. Run `jai build.jai - -release` to build the binary.
 4. Run `cd vscode_extension` to enter the subdirectory `vscode_extension`.
 5. Run `npm install` to install npm dependencies.


### PR DESCRIPTION
According to https://www.npmjs.com/package/vscode, the use of @vscode/vsc is deprecated and @types/vscode should be used instead.