### PR TITLE
Intermediate Path Support

### DIFF
--- a/metaprogram/jails_diagnostics.jai
+++ b/metaprogram/jails_diagnostics.jai
@@ -23,6 +23,14 @@ before_intercept :: (_p: *Plugin, flags: *Intercept_Flags) {
     p := cast(*Jails_Diagnostics_Plugin) _p;
     options := get_build_options(p.workspace);
     options.output_type = .NO_OUTPUT;
+    for arg : options.compile_time_command_line {
+        INTERIM_PATH_PREFIX :: "-JAILS_INTERM_PATH=";
+        if begins_with(arg, INTERIM_PATH_PREFIX) {
+            interim_path := slice(arg, INTERIM_PATH_PREFIX.count, arg.count - INTERIM_PATH_PREFIX.count);
+            options.intermediate_path = interim_path;
+            continue;
+        }
+    }
     set_build_options(options, p.workspace);
 }
 
@@ -33,3 +41,4 @@ shutdown :: (_p: *Plugin) {
 
 #import "Compiler";
 #import "Basic";
+#import "String";

--- a/readme.md
+++ b/readme.md
@@ -56,6 +56,7 @@ You can create a config file `jails.json` inside your project root to specify:
 - `roots` (`main.jai`, `build.jai`) - this is used to set up files that are being parsed on init - you don't need to set this but it will improve your experience.
 - `local modules` (`modules`) - this tells the language server to also search for modules in these folders.
 - `build_root` - entry file for compiling (currently used for running compiler diagnostics - errors in the editor)
+- `intermediate_path` - path where the language server will store intermediate files (like diagnostics)
 
 ```json
 {
@@ -66,7 +67,8 @@ You can create a config file `jails.json` inside your project root to specify:
         "server/main.jai",
         "build.jai"
     ],
-    "build_root": "build.jai"
+    "build_root": "build.jai",
+    "intermediate_path": "tmp/"
 }
 ```
 

--- a/server/diagnostics.jai
+++ b/server/diagnostics.jai
@@ -37,6 +37,12 @@ run_diagnostics :: () {
         array_add(*command, "-import_dir", local_module_folder);
     }
 
+    if server.intermediate_path.count > 0 {
+        joined := join(server.project_root, server.intermediate_path, "jails", separator="/",, temp);
+        normalised := normalize_path(joined,, temp);
+        array_add(*command, "-", tprint("-JAILS_INTERM_PATH=%", normalised));
+    }
+
     array_add(*command, "---", "import_dir", server.diagnostics_metaprogram_path);
 
     reset_diagnostics();

--- a/server/main.jai
+++ b/server/main.jai
@@ -16,6 +16,7 @@ Server :: struct {
     local_modules: [..]string;
     roots: []string;
     build_root: string;
+    intermediate_path: string;
 
     project_root: string;
     files: Table(string, *Program_File);
@@ -157,6 +158,7 @@ load_config_file :: () {
         roots: []string;
         build_root: string;
         jai_path: string;
+        intermediate_path: string;
     }
 
     config_path := join(server.project_root, "/jails.json");
@@ -176,6 +178,7 @@ load_config_file :: () {
 
     server.roots = config.roots;
     server.build_root = config.build_root;
+    server.intermediate_path = config.intermediate_path;
 
     if config.jai_path.count > 0 {
         server.args.jai_path = config.jai_path;
@@ -244,6 +247,7 @@ handle_request :: (request: LSP_Request_Message, raw_request: string) {
 
             log("Server.local_modules: %", server.local_modules);
             log("Server.roots: %", server.roots);
+            log("Server.intermediate_path: %", server.intermediate_path);
 
             for root: server.roots {
                 absolute_path: string;


### PR DESCRIPTION
- added a new config var `intermediate_path`
- this is passed to diagnostics metaprogram
- this will make it so that `*.w2_added_strings.jai` doesn't keep regenerating _inside_ the source files
- it was bothering me, because i had to add an awkward `.build/` dir to vcs

planning on contributing more to the repository
made this change to feel out how lsp + diagnostics + vscode extension flow works