### PR TITLE
Made procedure call textmate syntax recognized when it is on multiple lines

### DIFF
--- a/vscode_extension/syntaxes/jai.tmLanguage.json
+++ b/vscode_extension/syntaxes/jai.tmLanguage.json
@@ -1699,8 +1699,9 @@
 				},
 				{
 					"name": "meta.function.call.jai",
-					"match": "(([a-zA-Z_](?:\\w|\\\\ *)*)(\\.)(([a-zA-Z_](?:\\w|\\\\ *)*)(\\.))*)?\\b([a-zA-Z_](?:\\w|\\\\ *)*)\\s*(\\()(\\))",
-					"captures": {
+					"begin": "(([a-zA-Z_](?:\\w|\\\\ *)*)(\\.)(([a-zA-Z_](?:\\w|\\\\ *)*)(\\.))*)?\\b([a-zA-Z_](?:\\w|\\\\ *)*)\\s*(\\()",
+					"end": "(\\))",
+					"beginCaptures": {
 						"2": {
 							"name": "entity.name.namespace.jai"
 						},
@@ -1730,16 +1731,24 @@
 						},
 						"8": {
 							"name": "punctuation.section.parens.begin.jai"
-						},
-						"9": {
+						}
+					},
+					"endCaptures": {
+						"1": {
 							"name": "punctuation.section.parens.end.jai"
 						}
-					}
+					},
+					"patterns": [
+						{
+							"include": "$self"
+						}
+					]
 				},
 				{
 					"name": "meta.function.call.jai",
-					"match": "(([a-zA-Z_](?:\\w|\\\\ *)*)(\\.)(([a-zA-Z_](?:\\w|\\\\ *)*)(\\.))*)?\\b([a-zA-Z_](?:\\w|\\\\ *)*)\\s*(\\()(.*)(\\))",
-					"captures": {
+					"begin": "(([a-zA-Z_](?:\\w|\\\\ *)*)(\\.)(([a-zA-Z_](?:\\w|\\\\ *)*)(\\.))*)?\\b([a-zA-Z_](?:\\w|\\\\ *)*)\\s*(\\()(.*)",
+					"end": "(\\))",
+					"beginCaptures": {
 						"2": {
 							"name": "entity.name.namespace.jai"
 						},
@@ -1777,11 +1786,18 @@
 									"include": "#parameters"
 								}
 							]
-						},
-						"10": {
+						}
+					},
+					"endCaptures": {
+						"1": {
 							"name": "punctuation.section.parens.end.jai"
 						}
-					}
+					},
+					"patterns": [
+						{
+							"include": "$self"
+						}
+					]
 				}
 			],
 			"repository": {


### PR DESCRIPTION
Previously, procedure calls that take multiple lines weren't recognized:

Before:
<img width="908" height="453" alt="image" src="https://github.com/user-attachments/assets/29a4e74d-2635-429e-80bd-c84caf682f7d" />

The reason was that textmate pattern was using "match", which only checks a single line.

Changes:
- Replaced "match" with "begin" & "end" patterns without changing the original pattern.
- Replaced "captures" with "beginCaptures" & "endCaptures".
- Added "patterns": [{"include": "$self"}] to the end, that makes inside patterns work

After:
<img width="733" height="476" alt="image" src="https://github.com/user-attachments/assets/3f9b4b6a-74f6-45eb-8f0d-51158f11e61a" />