### PR TITLE
Add Jai debugging configuration for VSCode

### DIFF
--- a/vscode_extension/package.json
+++ b/vscode_extension/package.json
@@ -70,6 +70,52 @@
         "configuration": "./language-configuration.json"
       }
     ],
+    "debuggers": [
+      {
+        "type": "cppvsdbg",
+        "label": "Debug Jai (MSVC)",
+        "languages": [
+          "jai"
+        ],
+        "configurationAttributes": {
+          "launch": {
+            "required": [
+              "program"
+            ],
+            "properties": {
+              "program": {
+                "type": "string",
+                "description": "Path to the Jai executable",
+                "default": "${workspaceFolder}/program.exe"
+              },
+              "cwd": {
+                "type": "string",
+                "default": "${workspaceFolder}"
+              },
+              "stopAtEntry": {
+                "type": "boolean",
+                "default": false
+              }
+            }
+          }
+        },
+        "initialConfigurations": [
+          {
+            "name": "Debug Jai Executable",
+            "type": "cppvsdbg",
+            "request": "launch",
+            "program": "${workspaceFolder}/program.exe",
+            "cwd": "${workspaceFolder}",
+            "stopAtEntry": true
+          }
+        ]
+      }
+    ],
+    "breakpoints": [
+      {
+        "language": "jai"
+      }
+    ],
     "grammars": [
       {
         "language": "jai",


### PR DESCRIPTION
This change allows Jai debugging (MSVC by default) on VSCode after configuring `launch.json` file in `.vscode/` directory (creates a template if it doesn't exist).