### PR TITLE
Ensure build_install_extension.bat always changes back to Jails dir

### DIFF
--- a/build_install_extension.bat
+++ b/build_install_extension.bat
@@ -3,6 +3,4 @@ if %errorlevel% neq 0 exit /b %errorlevel%
 
 cd vscode_extension
 
-npm run compile && npm run pack:windows && code --install-extension .\jails-0.2.0.vsix
-
-cd ..
+npm run compile && npm run pack:windows && code --install-extension .\jails-0.2.0.vsix && cd ..


### PR DESCRIPTION
For some reason `cd ..` doesn't work on its own line. Maybe the npm stuff is setting error level even when it succeeds and that causes an early exit, I'm not sure. Moving it to `&& cd ..` seems to solve it.