### PR TITLE
Fix jails plugin argument order

### DIFF
--- a/server/diagnostics.jai
+++ b/server/diagnostics.jai
@@ -26,7 +26,7 @@ run_diagnostics :: () {
     defer array_free(command);
 
     array_add(*command, "jai");
-    array_add(*command, build_root_absolute, "-quiet", "-no_color", "+jails_diagnostics");
+    array_add(*command, build_root_absolute, "-quiet", "-no_color");
 
     // Use fast x64 backend on supported CPUs.
     if CPU == .X64 {
@@ -36,6 +36,8 @@ run_diagnostics :: () {
     for local_module_folder: server.local_modules {
         array_add(*command, "-import_dir", local_module_folder);
     }
+
+    array_add(*command, "+jails_diagnostics");
 
     if server.intermediate_path.count > 0 {
         joined := join(server.project_root, server.intermediate_path, "jails", separator="/",, temp);


### PR DESCRIPTION
This is regarding the discussion here:
https://discord.com/channels/661732390355337246/1392247452798550298/1394194798864240680

All `+` arguments need to come after all `-` arguments for it to work correctly in the latest version of Jai. This might only affect custom metaprograms or something, I'm not sure. It's been awhile. I have it patched locally and it's been working fine ever since.

A more comprehensive fix would also involve ensuring that the Jails diagnostics plugin throws an error when it encounters any unexpected `-` arguments, in order to prevent people from accidentally passing stuff in the wrong order and having build options be silently consumed by the plugin.