### PR TITLE
Small fix to how the output of whereis is processed.

### DIFF
--- a/.zed/debug.json
+++ b/.zed/debug.json
@@ -1,0 +1,20 @@
+// Project-local debug tasks
+//
+// For more documentation on how to configure debug tasks,
+// see: https://zed.dev/docs/debugger
+[
+    {
+        "label": "Jails",
+        "adapter": "CodeLLDB",
+        "request": "launch",
+        "cwd": "$ZED_WORKTREE_ROOT",
+        "program": "bin/jails",
+        "build": {
+            "cwd": "$ZED_WORKTREE_ROOT",
+            "command": "jai",
+            "args": [
+                "build.jai"
+            ]
+        }
+    }
+]

--- a/server/main.jai
+++ b/server/main.jai
@@ -135,7 +135,7 @@ find_jai_path :: (executable_name: string) -> string, string {
             result, raw_path, err = run_command("whereis", executable_name, capture_and_return_output=true);
         }
 
-        raw_path = replace(raw_path, tprint("%: ", executable_name), "");
+        raw_path = replace(raw_path, tprint("%:", executable_name), "");
         raw_path = trim(raw_path);
 
         BUFFER_SIZE :: 4096;


### PR DESCRIPTION
When I tried to run Jails on Linux I was hitting an assert, and it turned out that when jai-linux wasn't found in path it wasn't removing the prefix from the output because there was no space after the ':'.

Also, I added a simple Zed debug configuration that allowed me to step through jails in order to track this issue down.